### PR TITLE
fix(action): handle empty platform_hooks_path

### DIFF
--- a/action.py
+++ b/action.py
@@ -20,7 +20,7 @@ class Config:
     description: str
     docker_compose_path: Path
     environment_name: str
-    platform_hooks_path: Path
+    platform_hooks_path: Optional[Path]
     region: str
     version_label: str
 
@@ -278,7 +278,7 @@ if __name__ == "__main__":
             description=os.environ["VERSION_DESCRIPTION"],
             docker_compose_path=Path(os.environ["DOCKER_COMPOSE_PATH"]),
             environment_name=os.environ["ENVIRONMENT_NAME"],
-            platform_hooks_path=Path(os.environ["PLATFORM_HOOKS_PATH"]),
+            platform_hooks_path=Path(os.environ["PLATFORM_HOOKS_PATH"]) if os.environ["PLATFORM_HOOKS_PATH"] else None,
             region=os.environ["REGION"],
             version_label=os.environ["VERSION_LABEL"],
         ),


### PR DESCRIPTION
**Current problem:**

The `platform_hooks_path` is an empty string if it is not set as an input for this action. 
The result looks like this:
```python
>>> from pathlib import Path
>>> Path("")
PosixPath('.')
```

That means that the complete content of this action is copied to the target ZIP file.
```python
if platform_hooks_path is not None:
    for file in filter(lambda path: path.is_file(), platform_hooks_path.glob("**/*")):
        archive.write(file, arcname=file.relative_to(platform_hooks_path))
```

**Solution**
We would like to check if `platform_hooks_path` is an empty string and set it to None.

