### PR TITLE
feat(action): set aws default region to eu-central-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ steps:
       application_name: demo-app
       environment_name: "${{ format('demo-app-{0}', github.event.deployment.environment) }}"
       platform_hooks_path: "${{ github.workspace }}/beanstalk-platform-hooks"
-      region: eu-central-1
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
 With full list of parameters:
@@ -57,10 +59,12 @@ steps:
       docker_compose_path: "${{ github.workspace }}/docker/docker-compose.yml"
       environment_name: "${{ format('demo-app-{0}', github.event.deployment.environment) }}"
       platform_hooks_path: "${{ github.workspace }}/beanstalk-platform-hooks"
-      region: eu-central-1
       version_label: ${{ github.sha }}
       version_description: "GitHub Action #${{ github.run_number }}"
-
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
 ```
 
 # Local testing
@@ -70,7 +74,6 @@ Make sure that valid AWS credentials are exported into your profile, or located 
 export APPLICATION_NAME=demo-app
 export ENVIRONMENT_NAME=demo-app-dev
 export PLATFORM_HOOKS_PATH=beanstalk-platform-hooks
-export REGION=eu-central-1
 export VERSION_LABEL=SampleVersionLabel
 export VERSION_DESCRIPTION=SampleVersionDescription
 export DOCKER_COMPOSE_PATH=docker/docker-compose.yml

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,6 @@ inputs:
   platform_hooks_path:
     required: false
     description: "Path to hooks directory, which can contain .ebextensions and/or .platform folder"
-  region:
-    required: true
-    description: "Region of the Beanstalk platform"
   version_label:
     required: false
     description: "Version label (default: github.sha)"
@@ -40,11 +37,11 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
+        AWS_DEFAULT_REGION: eu-central-1
         APPLICATION_NAME: ${{ inputs.application_name }}
         DOCKER_COMPOSE_PATH: ${{ inputs.docker_compose_path }}
         ENVIRONMENT_NAME: ${{ inputs.environment_name }}
         PLATFORM_HOOKS_PATH: ${{ inputs.platform_hooks_path }}
-        REGION: ${{ inputs.region }}
         VERSION_DESCRIPTION: ${{ inputs.version_description }}
         VERSION_LABEL: ${{ inputs.version_label }}
 

--- a/test_action.py
+++ b/test_action.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -21,6 +22,23 @@ MOCK_APPLICATION = action.BeanstalkApplication(MOCK_CONFIG.application_name)
 MOCK_ENVIRONMENT = action.BeanstalkEnvironment(MOCK_APPLICATION, MOCK_CONFIG.environment_name)
 MOCK_APPLICATION_VERSION = action.ApplicationVersion(MOCK_APPLICATION, "version-0", "PROCESSED")
 MOCK_TIME = datetime.utcnow()
+
+
+class TestUtils(TestCase):
+    def test_check_aws_credentials(self):
+        with patch.dict(os.environ, {"AWS_ACCESS_KEY_ID": "fake", "AWS_SECRET_ACCESS_KEY": "fake"}):
+            action.check_aws_credentials()
+
+        with self.assertRaises(ValueError):
+            action.check_aws_credentials()
+
+    def test_get_region(self):
+        for variable in ("AWS_REGION", "AWS_DEFAULT_REGION"):
+            with patch.dict(os.environ, {variable: "us-east-1"}):
+                self.assertEqual(action.get_region(), "us-east-1")
+
+        with self.assertRaises(ValueError):
+            action.get_region()
 
 
 class TestApplicationVersion(TestCase):


### PR DESCRIPTION
I've decided to set the `AWS_DEFAULT_REGION` to `eu-central-1`, this will reduce our configuration. Our deployment step looks like this:

```yaml
- name: Deploy
  uses: moneymeets/action-beanstalk-deploy@master
  with:
    application_name: demo-app
    environment_name: demo-environment
  env:
    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
```

It is possible to override the region by specifying the `region` parameter as it was before without default.