### PR TITLE
Feature/use lint python composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
         uses: moneymeets/action-setup-python-poetry@master
 
       - name: Run linter
-        run: |
-          find . -name '*.py' | xargs poetry run add-trailing-comma --py36-plus
-          poetry run flake8
+        uses: moneymeets/moneymeets-composite-actions/lint-python@master
 
       - name: Test
         run: poetry run pytest --cov --cov-fail-under=84

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup Python + Poetry
-        uses: moneymeets/action-setup-python-poetry@master
+      - uses: moneymeets/action-setup-python-poetry@master
 
-      - name: Run linter
-        uses: moneymeets/moneymeets-composite-actions/lint-python@master
+      - uses: moneymeets/moneymeets-composite-actions/lint-python@master
 
-      - name: Test
-        run: poetry run pytest --cov --cov-fail-under=84
+      - run: poetry run pytest --cov --cov-fail-under=84


### PR DESCRIPTION
Now finishing up the repositories where our new `lint-python` composite action can still be used. 