### PR TITLE
feat(action): skip environment update if version is already active

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
 
       - uses: moneymeets/moneymeets-composite-actions/lint-python@master
 
-      - run: poetry run pytest --cov --cov-fail-under=84
+      - run: poetry run pytest --cov --cov-fail-under=85

--- a/action.py
+++ b/action.py
@@ -208,6 +208,10 @@ class ApplicationVersion:
     ):
         assert environment.application == self.application
 
+        if self.is_active_in_environment(environment):
+            logging.info(f"{self.version_label} already active in {environment.name}, skip update!")
+            return
+
         boto3.client("elasticbeanstalk").update_environment(
             ApplicationName=self.application.name,
             EnvironmentName=environment.name,


### PR DESCRIPTION
This fix solves the re-deploy of an existing version. This can happen if you trigger an environment update directly via AWS instead of GitHub action. If you trigger the deployment with same version later on with GitHub actions, the workflow should finish directly instead of updating the environment again.

Tested in: https://github.com/moneymeets/keycloak-docker/actions/runs/3384103226/jobs/5620683643 