### PR TITLE
feat(action): fix working directory for dependency installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Python + Poetry
-      uses: moneymeets/action-setup-python-poetry@master
+    - uses: moneymeets/action-setup-python-poetry@master
+      with:
+        working_directory: ${{ github.action_path }}
 
-    - name: Run
-      run: |
-        poetry install --no-dev
-        poetry run python action.py
+    - run: poetry run python action.py
       shell: bash
       working-directory: ${{ github.action_path }}
       env:


### PR DESCRIPTION
Fixes: https://github.com/moneymeets/action-beanstalk-deploy/issues/21

**HINT** Can be merged after https://github.com/moneymeets/action-setup-python-poetry/pull/9 is merged. And we need to update 
`uses: moneymeets/action-setup-python-poetry@feature/working-directory` 
to
`uses: moneymeets/action-setup-python-poetry@master`