### PR TITLE
feat(action): disable broken Poetry cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ runs:
     - uses: moneymeets/action-setup-python-poetry@master
       with:
         working_directory: ${{ github.action_path }}
+        # ToDo: Re-enable cache when https://github.com/actions/setup-python/issues/361 is fixed
+        poetry_cache_enabled: 'false'
 
     - run: poetry run python action.py
       shell: bash


### PR DESCRIPTION
We had the same problem with `merge-checks`, I've linked the issue. I think in this case we can disable it anyway, because the deployment trigger doesn't support restoring caches.